### PR TITLE
include octave version in mangOH yellow dependency

### DIFF
--- a/mangOH-yellow-Manifest.json
+++ b/mangOH-yellow-Manifest.json
@@ -16,7 +16,7 @@
             "mangOH-%MANGOH_BOARD%-%TARGET%-linux-image_%VERSION%",
             "swi-legato_latest",
             "wp77-legato-src_%LEGATO_VERSION%(LEGATO_SRC)",
-            "Octave-mangOH-%MANGOH_BOARD%-%TARGET%"
+            "Octave-mangOH-%MANGOH_BOARD%-%TARGET%_%VERSION%"
         ],
         "tags": [
             "mangOH",


### PR DESCRIPTION
I was getting this error when installing leaf packages:
```
$ leaf setup -p mangOH-yellow-wp77xx_0.2.0 wp77_mangOH_0.2.0
  -> Execute: leaf profile create wp77_mangOH_0.2.0
Current profile is now wp77_mangOH_0.2.0
Profile wp77_mangOH_0.2.0 created
  -> Execute: leaf profile config wp77_mangOH_0.2.0 -p mangOH-yellow-wp77xx_0.2.0
  -> Execute: leaf profile sync wp77_mangOH_0.2.0
Invalid conditional package identifier: Octave-mangOH-yellow-wp77xx
Command exited with 2
ERROR:
  Sub command failed: 'leaf profile sync wp77_mangOH_0.2.0'
```

I think the problem was that the Octave dependency didn't specify a version number component